### PR TITLE
Fix existing PNGs not being returned correctly

### DIFF
--- a/index.js
+++ b/index.js
@@ -4,7 +4,7 @@ const resizeImageData = require('resize-image-data')
 
 function toPng (image) {
   return (image.type === 'png')
-    ? Promise.resolve(Buffer.from(image.data.buffer, image.data.byteLength, image.data.byteOffset))
+    ? Promise.resolve(Buffer.from(image.data.buffer, image.data.byteOffset, image.data.byteLength))
     : lodepng.encode(image)
 }
 


### PR DESCRIPTION
The order for Buffer.from [is](https://nodejs.org/api/buffer.html#static-method-bufferfromarraybuffer-byteoffset-length) (and has been since [Node.js 8](https://nodejs.org/docs/latest-v8.x/api/buffer.html#buffer_class_method_buffer_from_arraybuffer_byteoffset_length), when [the line of code was added](https://github.com/LinusU/ico-to-png/commit/34efd7ef1aae16789e296f178507990a352438f3), so this won't break compatibility) `buffer, offset, length`. 

This library passed `buffer, length, offset`.